### PR TITLE
chore: migrate zod 3.x → 4.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "zod": "^3.23.8"
+        "zod": "^4.3.6"
       },
       "bin": {
         "ollama-intern-mcp": "dist/index.js"
@@ -2206,7 +2206,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/mcp-tool-shop-org/ollama-intern-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/src/guardrails/stringifiedArrayGuard.ts
+++ b/src/guardrails/stringifiedArrayGuard.ts
@@ -107,7 +107,7 @@ export function strictStringArray(
       }
       const res = real.safeParse(v);
       if (!res.success) {
-        for (const issue of res.error.issues) ctx.addIssue(issue);
+        for (const issue of res.error.issues) ctx.addIssue({ ...issue });
         return z.NEVER;
       }
       return res.data;

--- a/src/tools/extract.ts
+++ b/src/tools/extract.ts
@@ -35,7 +35,7 @@ export const extractSchema = z.object({
     .min(1)
     .optional()
     .describe("Batch of texts to extract from, each with a stable id. Returns one batch envelope with per-item {id, ok, result|error} entries."),
-  schema: z.record(z.unknown()).describe("JSONSchema the output must conform to — shared across all items in a batch."),
+  schema: z.record(z.string(), z.unknown()).describe("JSONSchema the output must conform to — shared across all items in a batch."),
   hint: z.string().optional().describe("Optional field-by-field hint."),
   per_file_max_chars: z.number().int().min(1000).max(200_000).optional().describe("Chars to read when source_path is used (default 40k)."),
 });


### PR DESCRIPTION
## Summary
Manual migration from zod 3.25.76 → 4.3.6. Supersedes #13 (which CI-failed because it was a naked dep bump without the two API fixes below).

## Changes
- **`src/tools/extract.ts:38`** — `z.record(z.unknown())` → `z.record(z.string(), z.unknown())`. Zod v4 makes the key type mandatory.
- **`src/guardrails/stringifiedArrayGuard.ts:110`** — `ctx.addIssue(issue)` → `ctx.addIssue({ ...issue })`. Zod v4's `$ZodIssue` lacks the index signature `addIssue` expects; spreading into a plain object satisfies it without changing semantics.

## Verification
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — 481/481 passing
- `npm run verify` — green end-to-end

## Follow-up
Once this lands, close #13.

## Test plan
- [x] typecheck passes
- [x] build passes
- [x] all 481 existing tests pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)