### PR TITLE
chore: upgrade TypeScript 5 → 6 + @types/node 20 → 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "ollama-intern-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^20.10.0",
+        "@types/node": "^22.19.17",
         "rimraf": "^5.0.5",
-        "typescript": "^5.3.3",
+        "typescript": "^6.0.3",
         "vitest": "^1.6.0"
       },
       "engines": {
@@ -164,7 +164,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1889,7 +1891,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.19.17",
     "rimraf": "^5.0.5",
-    "typescript": "^5.3.3",
+    "typescript": "^6.0.3",
     "vitest": "^1.6.0"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary
Manual migration from typescript 5.9.3 → 6.0.3 and @types/node 20 → 22. Supersedes #14 and #19 (auto-closed when its stacked base #18 was squash-merged).

## Changes
- **`package.json`** — `typescript: ^5.3.3 → ^6.0.3`, `@types/node: ^20.10.0 → ^22`
- **`tsconfig.json`** — added `"types": ["node"]`. TS 6 tightened ambient-type handling; bare `lib: ["ES2022"]` no longer implicitly pulls in node globals (`process`, `console`, `Buffer`, `node:` imports). Explicit `types: ["node"]` restores them.

Zero source-code changes needed. All 481 tests pass end-to-end.

## Verification
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — 481/481 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)