### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,10 +82,14 @@ jobs:
       - name: Ship gate (typecheck + build + test + pack check)
         run: npm run ship
 
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 22 bundles
+      # npm 10.9.x, so upgrade the global npm before the publish call.
+      - name: Upgrade npm for OIDC trusted publishing (>= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Publish to npm (with provenance)
+        # Auth via npm Trusted Publishing (OIDC) — intentionally NO NODE_AUTH_TOKEN.
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Auto-create a GitHub release on the tag-push path. We extract the
       # version's section from CHANGELOG.md (between "## [<version>]" and the


### PR DESCRIPTION
## Switch npm publish to OIDC Trusted Publishing

**Why this PR exists.** This repo's `publish.yml` authenticates `npm publish` with a `NODE_AUTH_TOKEN` wired to the `NPM_TOKEN` repo secret. That model just failed in production: on 2026-06-02, `@mcptoolshop/backprop-trace` v0.12.0 failed to release with an npm **E404** on the registry PUT. Root cause - the `NPM_TOKEN` secret had **expired**, and npm masks an expired/under-privileged token as a 404 (not a 403), which hid the real cause. Every repo still on this token pattern will hit the identical failure when its token expires.

**The fix** (identical to the already-proven backprop-trace migration):
- Remove the NODE_AUTH_TOKEN env (wired to the `NPM_TOKEN` secret) from the publish step.
- Add a step `npm install -g npm@latest` immediately before publish - OIDC trusted publishing requires npm >= 11.5.1, and Node 22 bundles npm 10.9.x.
- Keep `id-token: write` on the publish job.
- Keep `npm publish --provenance --access public`.

**Proof it works.** `@mcptoolshop/backprop-trace@0.12.0` is live on npm, published with `_npmUser.name: "GitHub Actions"` + a `trustedPublisher` block and a SLSA provenance attestation - exactly the end state this PR produces.

---

### ⚠️ BLOCKING PREREQUISITE - configure this on npmjs.com BEFORE merging

**This PR is intentionally a draft.** The code change is inert until a Trusted Publisher exists for the package, and merging without it will make the **next release fail** (no token, and no trusted publisher to fall back on).

1. [ ] On npmjs.com -> package **`ollama-intern-mcp`** -> **Settings -> Trusted Publishers** -> add a **GitHub Actions** publisher:
   - Owner/organization: `mcp-tool-shop-org`
   - Repository: `ollama-intern-mcp`
   - Workflow filename: `publish.yml`
   - Environment: *(leave blank)*
2. [ ] Mark this PR **Ready for review** and merge.
3. [ ] Cut the next release and confirm `npm view ollama-intern-mcp@<version> --json` shows `_npmUser.name: "GitHub Actions"` and a `trustedPublisher` block.
4. [ ] Only then delete the `NPM_TOKEN` repo secret (retained until now as a quick revert path - this PR does **not** delete it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
