### PR TITLE
fix(security): harden normalizeOllamaHost trailing-slash trim (CodeQL #24, js/polynomial-redos)

### DIFF
--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -279,7 +279,12 @@ export function normalizeOllamaHost(raw: string | undefined): string {
   const value = (raw ?? "").trim();
   if (!value) return fallback;
   const withScheme = /^https?:\/\//i.test(value) ? value : `http://${value}`;
-  const trimmed = withScheme.replace(/\/+$/, "");
+  // Strip ALL trailing slashes with a linear-time loop. A `/\/+$/` regex is the
+  // canonical polynomial-ReDoS shape (the unbounded `+` backtracks against the
+  // end anchor); `endsWith`/`slice` can't backtrack and is behaviourally
+  // identical ("http://h///" -> "http://h").
+  let trimmed = withScheme;
+  while (trimmed.endsWith("/")) trimmed = trimmed.slice(0, -1);
   // Validate port range if one is present. An out-of-range port lands as a
   // 'Invalid URL' error deep inside fetch() which turns into a generic
   // "Failed to reach Ollama" — CONFIG_INVALID at startup is the honest signal.

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -26,6 +26,14 @@ describe("normalizeOllamaHost", () => {
     expect(normalizeOllamaHost("http://127.0.0.1:11434///")).toBe("http://127.0.0.1:11434");
   });
 
+  it("strips a long run of trailing slashes in linear time (ReDoS-safe)", () => {
+    // CodeQL #24 (js/polynomial-redos): the old `/\/+$/` trim backtracked on a
+    // long trailing-slash run. The endsWith/slice loop is linear — a 100k-slash
+    // input resolves instantly and yields the bare host.
+    const host = `http://127.0.0.1:11434${"/".repeat(100_000)}`;
+    expect(normalizeOllamaHost(host)).toBe("http://127.0.0.1:11434");
+  });
+
   it("rejects an out-of-range port with CONFIG_INVALID", () => {
     // 70000 > 65535 — deep in fetch() this surfaced as "Failed to reach
     // Ollama"; we'd rather fail loud at startup with a clear hint.


### PR DESCRIPTION
@
## What

Closes CodeQL alert **#24** (`js/polynomial-redos`) at `src/ollama.ts:282`.

`normalizeOllamaHost()` stripped trailing slashes with `withScheme.replace(/\/+$/, "")`. The `/\/+$/` pattern (one-or-more, anchored to the end) is the canonical polynomial-ReDoS shape — the unbounded `+` backtracks against the end anchor. Replaced with a linear-time `endsWith`/`slice` loop that cannot backtrack.

```diff
-  const trimmed = withScheme.replace(/\/+$/, "");
+  let trimmed = withScheme;
+  while (trimmed.endsWith("/")) trimmed = trimmed.slice(0, -1);
```

Behaviour is **identical**: all trailing slashes are stripped (`"http://h///"` → `"http://h"`), and the existing `strips trailing slashes` test still passes unchanged.

## Why harden vs. dismiss

`OLLAMA_HOST` is an operator-set env var, not attacker- or HTTP-derived (see the by-design comment at `src/ollama.ts:274-276`), so the ReDoS was never practically reachable by an adversary — the same reasoning class used to dismiss the `js/http-to-file-access` MEDIUM in v2.7.1. But hardening is a one-liner with identical behaviour and removes the alert outright, which beats carrying a dismissed-FP forever.

## Test

Added a unit test feeding a 100k-trailing-slash host. It resolves instantly on the loop; the old regex would have backtracked. Full `npm run verify` green locally: typecheck + build + **1006 tests pass** (1 todo).

## Scope

Not a release. Lands on `main` for the next version bump — no tag/publish here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@