### PR TITLE
chore(quality): sweep 14 CodeQL js/unused-local-variable alerts (#7,#10-#22)

### DIFF
--- a/src/corpus/chunker.ts
+++ b/src/corpus/chunker.ts
@@ -130,7 +130,6 @@ function extractFrontmatter(text: string): { end: number; content: string } | nu
   const closeRx = /(^|\n)---\s*(\n|$)/;
   const m = closeRx.exec(rest);
   if (!m) return null;
-  const closeStart = afterOpen + 1 + m.index + (m[1] === "" ? 0 : 1);
   const closeEnd = afterOpen + 1 + m.index + m[0].length;
   return { end: closeEnd, content: text.slice(0, closeEnd) };
 }

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -442,11 +442,6 @@ export class HttpOllamaClient implements OllamaClient {
     // operator join "the wait that happened" with "the call that was
     // queued waiting" without timestamp guesswork.
     const callId = mintCallId();
-    // Map endpoint path → OTel `op` value (Phase 7 / FT-001). The
-    // mapping is deterministic from the path so callers don't need to
-    // pass an `op` parameter. /api/embed → embeddings; everything else
-    // (generate, chat) → chat per the OTel GenAI convention.
-    const op = path === "/api/embed" ? "embeddings" : "chat";
     // Before acquiring, peek at the gate. If we'd block, emit a single
     // semaphore:wait event with queue depth + rough wait estimate so an
     // operator debugging "why was this slow?" has the context they need.

--- a/src/tools/corpusAnswer.ts
+++ b/src/tools/corpusAnswer.ts
@@ -25,7 +25,7 @@
 import { z } from "zod";
 import type { Envelope } from "../envelope.js";
 import { buildEnvelope } from "../envelope.js";
-import { TEMPERATURE_BY_SHAPE, resolveTier, resolveNumCtx } from "../tiers.js";
+import { TEMPERATURE_BY_SHAPE, resolveTier } from "../tiers.js";
 import { runTool } from "./runner.js";
 import { callEvent, timestamp } from "../observability.js";
 import { loadCorpus } from "../corpus/storage.js";

--- a/tests/corpus/atomicWrite.test.ts
+++ b/tests/corpus/atomicWrite.test.ts
@@ -24,8 +24,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, readFile, rm, stat, writeFile, chmod } from "node:fs/promises";
-import { tmpdir, platform } from "node:os";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { atomicWriteFile } from "../../src/corpus/atomicWrite.js";

--- a/tests/corpus/chunker.test.ts
+++ b/tests/corpus/chunker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { chunk, chunkDocument, DEFAULT_CHUNK } from "../../src/corpus/chunker.js";
+import { chunk, chunkDocument } from "../../src/corpus/chunker.js";
 
 describe("chunker", () => {
   it("returns empty array for empty text", () => {

--- a/tests/corpus/indexerSearcher.test.ts
+++ b/tests/corpus/indexerSearcher.test.ts
@@ -164,7 +164,7 @@ describe("indexCorpus + searchCorpus", () => {
     await writeFile(p1, "original content", "utf8");
 
     const client = new HashEmbedMock();
-    const r1 = await indexCorpus({ name: "ch", paths: [p1], model: "nomic-embed-text", client });
+    await indexCorpus({ name: "ch", paths: [p1], model: "nomic-embed-text", client });
     const embedsAfterFirst = client.embedCalls;
 
     await writeFile(p1, "completely different content now, longer too", "utf8");

--- a/tests/corpus/searchModes.test.ts
+++ b/tests/corpus/searchModes.test.ts
@@ -25,7 +25,6 @@ import type {
   EmbedResponse,
 } from "../../src/ollama.js";
 import type { Residency } from "../../src/envelope.js";
-import { InternError } from "../../src/errors.js";
 
 // ── Helpers ─────────────────────────────────────────────────
 

--- a/tests/corpus/stageBCFixes.test.ts
+++ b/tests/corpus/stageBCFixes.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile, readFile, unlink } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 

--- a/tests/evals/retrieval.test.ts
+++ b/tests/evals/retrieval.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { describe, it, expect, beforeAll } from "vitest";
-import { readdir, mkdtemp, rm } from "node:fs/promises";
+import { readdir, mkdtemp } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -36,7 +36,6 @@ import {
   type EvalSummary,
   type EvalRecord,
 } from "../../src/evals/retrieval.js";
-import { SEARCH_MODES } from "../../src/corpus/searcher.js";
 import type {
   OllamaClient,
   GenerateRequest,

--- a/tests/guardrails/timeouts.test.ts
+++ b/tests/guardrails/timeouts.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { runWithTimeoutAndFallback } from "../../src/guardrails/timeouts.js";
 import { NullLogger } from "../../src/observability.js";
-import { InternError } from "../../src/errors.js";
 
 describe("runWithTimeoutAndFallback", () => {
   it("returns the value when run() resolves before timeout", async () => {

--- a/tests/observability.test.ts
+++ b/tests/observability.test.ts
@@ -33,7 +33,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, sep } from "node:path";
+import { join } from "node:path";
 
 import {
   NullLogger,

--- a/tests/tools/repoPack.test.ts
+++ b/tests/tools/repoPack.test.ts
@@ -187,7 +187,7 @@ describe("handleRepoPack — fixed pipeline", () => {
       { name: "package.json", content: '{"name":"@mcptoolshop/foundry","scripts":{"build":"tsc"}}' },
     ]);
     const client = new PipelineMock(BRIEF_OUT, EXTRACT_OUT);
-    const env = await handleRepoPack(
+    await handleRepoPack(
       { source_paths: paths, title: "FoundryOS", artifact_dir: tempArtifactDir },
       makeCtx(client),
     );


### PR DESCRIPTION
## What

Sweeps the **14 remaining open CodeQL alerts**, all `js/unused-local-variable` (alerts #7, #10–#22). Pure dead-code removal — no behaviour change.

| Alert | File | Removed |
|------|------|---------|
| #7 | `src/corpus/chunker.ts` | unused `closeStart` (only `closeEnd` is returned) |
| #10 | `src/ollama.ts` | dead `op` const + its comment block¹ |
| #11 | `src/tools/corpusAnswer.ts` | unused import `resolveNumCtx` |
| #12 | `tests/corpus/chunker.test.ts` | `DEFAULT_CHUNK` |
| #13/#14 | `tests/corpus/atomicWrite.test.ts` | `chmod`, `platform` |
| #15 | `tests/corpus/indexerSearcher.test.ts` | unused `r1` binding² |
| #16 | `tests/corpus/searchModes.test.ts` | `InternError` |
| #17 | `tests/corpus/stageBCFixes.test.ts` | `unlink` |
| #18/#19 | `tests/evals/retrieval.test.ts` | `rm`, `SEARCH_MODES` |
| #20 | `tests/guardrails/timeouts.test.ts` | `InternError` |
| #21 | `tests/observability.test.ts` | `sep` |
| #22 | `tests/tools/repoPack.test.ts` | unused `env` binding² |

¹ The `op` const was orphaned — the semaphore_wait event uses the hardcoded `op: "semaphore_wait"` literal and joins to the chat/embeddings event by `call_id`, not this variable.
² Binding removed but the side-effecting `await` call is kept (it performs the actual index / artifact write the test relies on downstream).

## Verify

`npm run verify` green locally: typecheck + build + **1006 tests pass** (1 todo). After merge, no open security-severity CodeQL alerts remain (alert #24, the lone HIGH ReDoS, was fixed in [#36](https://github.com/mcp-tool-shop-org/ollama-intern-mcp/pull/36)).

## Scope

Not a release. Lands on `main` for the next version bump — no tag/publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
