### PR TITLE
fix(cloud): non-thinking default + think=false on chat + 4096 output budget

### DIFF
--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -211,6 +211,14 @@ export interface ChatRequest {
   format?: "json";
   stream?: boolean;
   options?: GenerateRequest["options"];
+  /**
+   * Thinking-mode toggle — same semantics as GenerateRequest.think. Without
+   * this field the chat path could never suppress CoT, so a thinking model
+   * (e.g. minimax-m3:cloud) burned the entire num_predict budget on thinking
+   * tokens and returned an empty `message.content` (observed live 2026-06-09
+   * against Ollama Cloud). Non-thinking models ignore the field.
+   */
+  think?: boolean;
   keep_alive?: string | number;
 }
 

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -369,13 +369,20 @@ export interface CloudConfig {
 
 const CLOUD_DEFAULT_HOST = "https://ollama.com";
 /**
- * Default cloud model. minimax-m3:cloud is the current flagship successor to
- * the 2026-06-16-retiring minimax-m2 — fast for a big model, 512K–1M context
- * (fits the file-reading flagship tools), thinking-capable. NEVER default to a
- * deprecation-listed id (minimax-m2, glm-4.6, kimi-k2:1t, cogito-2.1:671b,
- * qwen3-vl:235b).
+ * Default cloud model. MUST be a NON-thinking model: the default serves
+ * instant+workhorse, where short-output tools cap num_predict tightly — a
+ * thinking default burns that budget on CoT and returns empty replies (the
+ * 2026-06-09 minimax-m3:cloud incident: cloud reachable, every chat reply "").
+ * qwen3-coder-next:cloud is explicitly non-thinking ("no <think> blocks",
+ * 80B-A3B, 256K ctx) per ollama.com/library/qwen3-coder-next, checked
+ * 2026-06-09 — cloud ids are volatile; re-check ollama.com/search?c=cloud
+ * before re-pinning. Big thinking models (glm-5, deepseek-v4-pro, kimi-k2.x)
+ * belong on INTERN_CLOUD_DEEP_MODEL, where tools size num_predict for
+ * reasoning + response together. NEVER default to a deprecation-listed id
+ * (minimax-m2, glm-4.6, kimi-k2:1t, cogito-2.1:671b, qwen3-vl:235b,
+ * qwen3-coder:480b — the latter 404s as of 2026-06-09).
  */
-const CLOUD_DEFAULT_MODEL = "minimax-m3:cloud";
+const CLOUD_DEFAULT_MODEL = "qwen3-coder-next:cloud";
 const CLOUD_DEFAULT_TIMEOUTS: Record<Tier, number> = {
   instant: 30_000,
   workhorse: 120_000,
@@ -414,8 +421,10 @@ function positiveIntEnv(raw: string | undefined, fallback: number): number {
  *   OLLAMA_CLOUD_PRIMARY        opt-in switch (1/true/yes/on)
  *   OLLAMA_API_KEY              bearer key (required when enabled)
  *   OLLAMA_CLOUD_HOST           default https://ollama.com
- *   INTERN_CLOUD_MODEL          default minimax-m3:cloud (instant+workhorse+deep)
- *   INTERN_CLOUD_DEEP_MODEL     optional deep-only override (e.g. deepseek-v3.1:671b)
+ *   INTERN_CLOUD_MODEL          default qwen3-coder-next:cloud (instant+workhorse+deep;
+ *                               keep NON-thinking — see CLOUD_DEFAULT_MODEL)
+ *   INTERN_CLOUD_DEEP_MODEL     optional deep-only override (e.g. glm-5:cloud,
+ *                               deepseek-v4-pro:cloud — thinking OK here)
  *   INTERN_CLOUD_TIMEOUT_*_MS   per-tier cloud timeouts (instant/workhorse/deep)
  *   INTERN_CLOUD_NUM_CTX        cloud context-window cap (default 32768)
  */

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -12,7 +12,7 @@ import { buildEnvelope } from "../envelope.js";
 import { callEvent } from "../observability.js";
 import type { ChatMessage } from "../ollama.js";
 import { countTokens } from "../ollama.js";
-import { resolveTier, resolveNumCtx, TEMPERATURE_BY_SHAPE } from "../tiers.js";
+import { resolveTier, resolveNumCtx, TEMPERATURE_BY_SHAPE, THINK_BY_SHAPE } from "../tiers.js";
 import type { RunContext } from "../runContext.js";
 
 export const chatSchema = z.object({
@@ -66,15 +66,23 @@ export async function handleChat(
   // TIER_FALLBACK, so a single resolved value covers the whole call.
   // Absent when the active profile doesn't set workhorse num_ctx.
   const numCtx = resolveNumCtx("workhorse", ctx.tiers);
+  // 4096 (was 1024): chat is the catch-all that long-form jobs (canon
+  // authoring, dense prose) fall back to when no specialty tool fits; 1024
+  // truncated those even on non-thinking models. Generous but bounded.
   const options: { temperature?: number; num_predict?: number; num_ctx?: number } = {
     temperature: TEMPERATURE_BY_SHAPE.chat,
-    num_predict: 1024,
+    num_predict: 4096,
     ...(numCtx !== undefined ? { num_ctx: numCtx } : {}),
   };
   const resp = await ctx.client.chat({
     model,
     messages,
     options,
+    // chat was the ONLY generate-shaped tool not passing `think`. On a
+    // thinking model CoT consumed the whole num_predict and `content` came
+    // back empty (the 2026-06-09 minimax-m3:cloud incident). Same doctrine
+    // as draft/extract/etc.: short-form shapes suppress CoT.
+    think: THINK_BY_SHAPE.chat,
   });
   const tokens = countTokens(resp);
   const residency = await ctx.client.residency(model);

--- a/tests/cloudConfig.test.ts
+++ b/tests/cloudConfig.test.ts
@@ -43,13 +43,13 @@ describe("loadCloudConfig — gating", () => {
 });
 
 describe("loadCloudConfig — defaults", () => {
-  it("uses minimax-m3:cloud across generative tiers, ollama.com host, 32768 num_ctx", () => {
+  it("uses qwen3-coder-next:cloud (non-thinking) across generative tiers, ollama.com host, 32768 num_ctx", () => {
     const cfg = loadCloudConfig({ OLLAMA_CLOUD_PRIMARY: "1", ...KEY })!;
     expect(cfg.host).toBe("https://ollama.com");
     expect(cfg.apiKey).toBe("sk-test-123");
-    expect(cfg.tiers.instant).toBe("minimax-m3:cloud");
-    expect(cfg.tiers.workhorse).toBe("minimax-m3:cloud");
-    expect(cfg.tiers.deep).toBe("minimax-m3:cloud");
+    expect(cfg.tiers.instant).toBe("qwen3-coder-next:cloud");
+    expect(cfg.tiers.workhorse).toBe("qwen3-coder-next:cloud");
+    expect(cfg.tiers.deep).toBe("qwen3-coder-next:cloud");
     expect(cfg.tiers.embed).toBe("nomic-embed-text");
     expect(cfg.numCtx).toBe(32_768);
     expect(cfg.timeouts).toEqual({ instant: 30_000, workhorse: 120_000, deep: 300_000, embed: 10_000 });
@@ -63,7 +63,7 @@ describe("loadCloudConfig — overrides", () => {
       ...KEY,
       INTERN_CLOUD_DEEP_MODEL: "deepseek-v3.1:671b",
     })!;
-    expect(cfg.tiers.instant).toBe("minimax-m3:cloud");
+    expect(cfg.tiers.instant).toBe("qwen3-coder-next:cloud");
     expect(cfg.tiers.deep).toBe("deepseek-v3.1:671b");
   });
 

--- a/tests/tools/chat.test.ts
+++ b/tests/tools/chat.test.ts
@@ -40,6 +40,26 @@ describe("handleChat — baseline", () => {
   });
 });
 
+describe("handleChat — thinking suppression + output budget (v2.7.3)", () => {
+  it("passes think=false and num_predict=4096 to the underlying chat call", async () => {
+    const client = createFakeOllama({
+      chatImpl: async (req) => ({
+        model: req.model,
+        message: { role: "assistant", content: "ok" },
+        done: true,
+        prompt_eval_count: 10,
+        eval_count: 5,
+      }),
+    });
+    await handleChat({ messages: [{ role: "user", content: "hi" }] }, makeFakeCtx({ client }));
+    // Regression guard for the 2026-06-09 cloud incident: chat was the only
+    // generate-shaped tool not passing `think`, so a thinking cloud model
+    // burned the whole (then-1024) num_predict on CoT and replied "".
+    expect(client.lastChat?.think).toBe(false);
+    expect(client.lastChat?.options?.num_predict).toBe(4096);
+  });
+});
+
 describe("handleChat — per-call model override (v2.3.0)", () => {
   it("input.model is passed to the underlying Ollama chat call", async () => {
     const client = createFakeOllama({


### PR DESCRIPTION
## The bug (observed live 2026-06-09)

With `OLLAMA_CLOUD_PRIMARY` enabled, the intern reached Ollama Cloud but every `ollama_chat` reply came back **empty**. Three compounding causes:

1. **`chat` was the only generate-shaped tool not passing `think`** — and `ChatRequest` had no such field, so the `/api/chat` path could never suppress CoT. On a thinking model (`minimax-m3:cloud`, the old default) the entire `num_predict` budget was consumed by thinking tokens → `message.content` = `""`.
2. **`num_predict: 1024` hard cap** on the chat catch-all — too small for the long-form jobs (dense canon authoring) that fall back to it, even on non-thinking models.
3. **The default cloud model was a thinking model.** The default serves instant+workhorse, where short-output tools cap `num_predict` tightly — the default must be non-thinking.

## The fix

- `ChatRequest` gains `think?: boolean`; `handleChat` passes `THINK_BY_SHAPE.chat` (false) — the exact doctrine draft/extract/classify/triage already follow.
- chat `num_predict` 1024 → 4096.
- `CLOUD_DEFAULT_MODEL` → `qwen3-coder-next:cloud` — explicitly non-thinking ("no `<think>` blocks", 80B-A3B MoE, 256K ctx; verified on ollama.com 2026-06-09). Big thinking models (glm-5, deepseek-v4-pro) remain available via `INTERN_CLOUD_DEEP_MODEL`, where tools size budgets for CoT + response. Doc comments updated, including the deprecation list (`qwen3-coder:480b` 404s now).

## Verification

- Live canon-gen through the signed-in local daemon cloud proxy: `qwen3-coder-next:cloud` returned a 1,452-char dense bestiary-canon entry (357 eval tokens) — content, not `""`.
- New regression test pins `think === false` + `num_predict === 4096` on the chat path.
- Full suite: **83 files, 1007 passed, 1 todo.**
- Also pulled `hermes3:8b` locally on the rig (the local-ladder default was unpulled → 404s; rig-side fix, no code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)