### PR TITLE
ci: bump Actions to Node 24 (June 16 deprecation)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -159,7 +159,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -169,7 +169,7 @@ jobs:
             type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build & push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: ${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}


### PR DESCRIPTION
Bumps 3 Node-20 action pin(s) to their latest Node-24 SHA-pinned releases ahead of GitHub's 2026-06-16 forced-Node-24 cutover.

Actions: docker/build-push-action, docker/login-action, docker/metadata-action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)